### PR TITLE
refactor: update media query to use JSON_ARRAY for thumbnails and enh…

### DIFF
--- a/src/api/models/mediaModel.ts
+++ b/src/api/models/mediaModel.ts
@@ -33,13 +33,13 @@ const BASE_MEDIA_QUERY = `
     CASE
       WHEN media_type NOT LIKE '%image%'
       THEN (
-        SELECT JSON_ARRAYAGG(
-          CONCAT(base_url, filename, '-thumb-', n, '.png')
+        SELECT JSON_ARRAY(
+          CONCAT(base_url, filename, '-thumb-1.png'),
+          CONCAT(base_url, filename, '-thumb-2.png'),
+          CONCAT(base_url, filename, '-thumb-3.png'),
+          CONCAT(base_url, filename, '-thumb-4.png'),
+          CONCAT(base_url, filename, '-thumb-5.png')
         )
-        FROM (
-          SELECT 1 AS n UNION SELECT 2 UNION SELECT 3
-          UNION SELECT 4 UNION SELECT 5
-        ) numbers
       )
       ELSE NULL
     END AS screenshots

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -10,8 +10,15 @@ const promisePool = mysql.createPool({
   queueLimit: 0,
   // Convert JSON fields to objects
   typeCast: function (field, next) {
-    if (field.type === 'JSON') {
-      const fieldValue = field.string('utf8');
+    console.log('TypeCast field:', {
+      type: field.type,
+      name: field.name,
+      table: field.table,
+    });
+    // Check for both string 'JSON' and MySQL type code 245
+    if (field.name === 'screenshots') {
+      const fieldValue = field.string();
+      console.log('JSON field value:', fieldValue);
       if (fieldValue) {
         try {
           return JSON.parse(fieldValue);


### PR DESCRIPTION
…ance type casting for JSON fields

## Summary by Sourcery

Update the media query to use JSON_ARRAY for thumbnails and enhance type casting for the `screenshots` field.

Enhancements:
- Use `JSON_ARRAY` instead of `JSON_ARRAYAGG` to generate the thumbnails array, simplifying the query.
- Improve type casting for the `screenshots` field by checking the field name and handling potential parsing errors.