### PR TITLE
fix: throw custom error for unauthorized media deletion attempts

### DIFF
--- a/src/api/models/mediaModel.ts
+++ b/src/api/models/mediaModel.ts
@@ -144,7 +144,7 @@ const deleteMedia = async (
 
   const isOwner = await checkOwnership(media_id, user_id);
   if (!isOwner && level_name !== 'Admin') {
-    return {message: 'Not authorized to delete media'};
+    throw new CustomError(ERROR_MESSAGES.MEDIA.NOT_DELETED, 403);
   }
 
   media.filename = media?.filename.replace(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Throw a custom error when a user attempts to delete media without authorization.